### PR TITLE
fixed atari atr build to include picoboot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
-# Makefile for fujinet-build-tools makefiles
+# Makefile for CATER 2024
+# this is using the local makefiles, copied from the fujinet-build-tools/makefiles 
+# based on the work done by fenrock but not supported by him
 
 # Set the TARGETS and PROGRAM values as required.
-
 TARGETS = apple2enh atari
 PROGRAM := cater
 
 SUB_TASKS := clean disk test release
 .PHONY: all help $(SUB_TASKS)
 
-export FUJINET_BUILD_TOOLS_DIR := ../../fujinet-build-tools
+# Set the FUJINET_BUILD_TOOLS_DIR to be the same directory as we are in now....
+export FUJINET_BUILD_TOOLS_DIR := .
 export FUJINET_LIB_VERSION := 4.3.1
 
 all:

--- a/makefiles/custom-atari.mk
+++ b/makefiles/custom-atari.mk
@@ -1,5 +1,7 @@
 # COMPILE FLAGS
 
+$(info >>>>Starting custom-atari.mk)
+
 # reserved memory for graphics
 # LDFLAGS += -Wl -D,__RESERVED_MEMORY__=0x2000
 
@@ -13,10 +15,14 @@ SUFFIX = .com
 DISK_TASKS += .atr
 
 .atr:
+	$(info >>>> MAKING ATR)
+
 	$(call MKDIR,$(DIST_DIR)/atr)
 	cp $(DIST_DIR)/$(PROGRAM_TGT)$(SUFFIX) $(DIST_DIR)/atr/$(PROGRAM)$(SUFFIX)
 	$(call RMFILES,$(DIST_DIR)/*.atr)
-	dir2atr -S $(DIST_DIR)/$(PROGRAM).atr $(DIST_DIR)/atr
+	cp ../fujinet-build-tools/picoboot.bin $(DIST_DIR)/
+	dir2atr -m -S -B $(DIST_DIR)/picoboot.bin $(DIST_DIR)/$(PROGRAM).atr $(DIST_DIR)/atr
+
 
 
 ################################################################


### PR DESCRIPTION
ATR is bootable now, need to still sort out where picoboot will reside long term and the FN lib isn't working well with cater and SIO when connected to a host.