### PR TITLE
updating cater.cfg to fix 'unresolved external __INIT_LOAD__' error

### DIFF
--- a/src/atari/cater.cfg
+++ b/src/atari/cater.cfg
@@ -45,7 +45,7 @@ SEGMENTS {
     CODE:      load = MAIN,       type = ro,  define = yes;
     RODATA:    load = MAIN,       type = ro;
     DATA:      load = MAIN,       type = rw;
-    INIT:      load = MAIN,       type = rw,                optional = yes;
+    INIT:      load = MAIN,       type = rw,  define = yes, optional = yes;
     BSS:       load = MAIN,       type = bss, define = yes;
     FONTHDR:   load = FONTHDR,    type = ro;
     FONT:      load = FONT,       type = ro;


### PR DESCRIPTION
Atari target was failing to link with:
```bash
atari/exehdr.s:11: Warning: Unresolved external ‘__INIT_LOAD__’
ld65: Error: 1 unresolved external(s) found - cannot create output file
```
Updated src/atari/cater.cfg by adding `define = yes,` to INIT: segment